### PR TITLE
feat: 스웨거 세팅 추가

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
 spring:
   profiles:
     active: local
+
+springdoc:
+  swagger-ui:
+    path: /docs


### PR DESCRIPTION
## Related issue 🛠

<!-- 관련 이슈 번호를 적어주세요 -->
- closes #18 

## Work Description ✏️

스웨거 ui 경로를 /docs로 간편화하기 위해 yml 파일에 해당 경로를 명시해주었습니다.

## Trouble Shooting ⚽️

## Related ScreenShot 📷

![image](https://github.com/user-attachments/assets/e00b8a15-d2c9-4171-8c86-9742d817e0e8)


## Uncompleted Tasks 😅

<!-- 끝내지 못한 작업을 적어주세요 -->

## To Reviewers 📢
이제 스웨거 ui 접속 시 /docs 경로로 접근하시면 됩니다!